### PR TITLE
Refactor action handling in PPO agent

### DIFF
--- a/src/sisyphus/tasks/fsmn_agent.py
+++ b/src/sisyphus/tasks/fsmn_agent.py
@@ -36,11 +36,12 @@ class PPOLightningAgent(LightningModule):
         self.avg_ent_loss = MeanMetric(**torchmetrics_kwargs)
 
     def get_action_and_value(
-        self, x: Tensor, action_cache: Tensor = None
+        self, x: Tensor, action: Tensor | None = None
     ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
         action_logits, value, _ = self.actor_critic.get_action_value(x)
         distribution = Categorical(logits=action_logits)
-        action = distribution.sample()
+        if action is None:
+            action = distribution.sample()
         log_prob = distribution.log_prob(action)
         entropy = distribution.entropy()
         action = action.squeeze(-1)
@@ -53,7 +54,7 @@ class PPOLightningAgent(LightningModule):
         return value
 
     def forward(
-        self, x: Tensor, action: Tensor = None
+        self, x: Tensor, action: Tensor | None = None
     ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
         return self.get_action_and_value(x, action)
 


### PR DESCRIPTION
## Summary
- allow PPO agent to compute log probabilities for provided actions
- forward pass accepts optional action tensor

## Testing
- `PYTHONPATH=src pytest -q`
- `WANDB_MODE=offline PYTHONPATH=src python - <<'PY'
from dataclasses import dataclass
from sisyphus.trainer.train import main

@dataclass
class PPOConfig:
    exp_name: str = 'default'
    seed: int = 0
    cuda: bool = False
    torch_deterministic: bool = False
    num_envs: int = 4
    share_data: bool = False
    per_rank_batch_size: int = 32
    env_id: str = 'CartPole-v1'
    num_steps: int = 64
    capture_video: bool = False
    total_timesteps: int = 4096
    learning_rate: float = 1e-3
    anneal_lr: bool = False
    gamma: float = 0.99
    gae_lambda: float = 0.95
    update_epochs: int = 2
    normalize_advantages: bool = False
    clip_coef: float = 0.2
    clip_vloss: bool = False
    ent_coef: float = 0.0
    vf_coef: float = 1.0
    max_grad_norm: float = 0.5

args = PPOConfig()
main(args)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ab2f22605883288d906f974067c12e